### PR TITLE
Add test suite for advanced dataset selection components

### DIFF
--- a/AdvancedDatasetSelection/Tests/test_combined_selector.py
+++ b/AdvancedDatasetSelection/Tests/test_combined_selector.py
@@ -1,0 +1,129 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+
+# Ensure project root is on the path
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from AdvancedDatasetSelection.selection_methods.combined_selector import CombinedSelector
+from AdvancedDatasetSelection.selection_methods.k_center_greedy import KCenterGreedy
+from AdvancedDatasetSelection.feature_extractors.fourier_analyzer import FourierAnalyzer
+
+
+class _DummyDINO:
+    def compute_features_batch(self, image_paths, show_progress=True):  # pragma: no cover - simple stub
+        rng = np.random.default_rng(0)
+        return rng.normal(size=(len(image_paths), 4)), image_paths
+
+
+class _DummySAM:
+    def compute_complexity_without_sam(self, image):  # pragma: no cover - simple stub
+        return {"complexity_score": float(np.mean(image) / 255.0)}
+
+
+class _DummyEL2N:
+    pass
+
+
+class _DummySelector(CombinedSelector):
+    def __init__(self):
+        super().__init__(
+            fourier_analyzer=FourierAnalyzer(similarity_threshold=0.9),
+            dino_extractor=_DummyDINO(),
+            sam_extractor=_DummySAM(),
+            el2n_scorer=_DummyEL2N(),
+            k_center=KCenterGreedy(distance_metric="euclidean"),
+        )
+
+    def extract_all_features(self, image_paths, labels=None, use_cache=True, show_progress=True):  # pragma: no cover - controlled in tests
+        rng = np.random.default_rng(2)
+        self.fourier_features = rng.normal(size=(len(image_paths), 5))
+        self.dino_features = rng.normal(size=(len(image_paths), 4))
+        self.sam_scores = rng.random(len(image_paths))
+        self.el2n_scores = np.linspace(0.0, 1.0, len(image_paths))
+        self.valid_paths = list(image_paths)
+        return {
+            "fourier_features": self.fourier_features,
+            "dino_features": self.dino_features,
+            "sam_scores": self.sam_scores,
+            "el2n_scores": self.el2n_scores,
+            "valid_paths": self.valid_paths,
+        }
+
+
+def test_stepwise_selection_with_manual_features():
+    np.random.seed(0)
+    selector = CombinedSelector(
+        fourier_analyzer=FourierAnalyzer(similarity_threshold=0.95),
+        dino_extractor=_DummyDINO(),
+        sam_extractor=_DummySAM(),
+        el2n_scorer=_DummyEL2N(),
+        k_center=KCenterGreedy(distance_metric="euclidean"),
+    )
+
+    selector.fourier_features = np.array(
+        [
+            [1, 0, 0, 0, 0],
+            [1, 0, 0, 0, 0],
+            [0, 1, 0, 0, 0],
+            [0, 1, 0, 0, 0],
+            [0, 0, 1, 0, 0],
+            [0, 0, 1, 0, 0],
+        ],
+        dtype=float,
+    )
+    selector.valid_paths = [f"img_{i}.jpg" for i in range(6)]
+    selector.dino_features = np.array(
+        [
+            [0.1, 0.2, 0.3, 0.4],
+            [0.2, 0.3, 0.4, 0.5],
+            [0.5, 0.4, 0.3, 0.2],
+            [0.6, 0.5, 0.4, 0.3],
+            [0.9, 1.0, 1.1, 1.2],
+            [1.0, 1.1, 1.2, 1.3],
+        ]
+    )
+    selector.sam_scores = np.linspace(0.0, 1.0, 6)
+    selector.el2n_scores = np.array([0.1, 0.2, 0.3, 0.5, 0.7, 0.6])
+
+    step1_indices, step1_paths = selector.step1_fourier_prefilter(threshold=0.9)
+
+    assert step1_indices == [0, 2, 4]
+    assert step1_paths == ["img_0.jpg", "img_2.jpg", "img_4.jpg"]
+
+    combined = selector.step2_combine_features(step1_indices)
+    assert combined.shape == (3, selector.dino_features.shape[1] + 1)
+
+    np.random.seed(1)
+    step3_indices = selector.step3_k_center_select(
+        combined_features=combined,
+        original_indices=step1_indices,
+        target_size=2,
+        oversampling=1.0,
+    )
+
+    assert len(step3_indices) == 2
+    assert set(step3_indices).issubset(set(step1_indices))
+
+    final_indices = selector.step4_el2n_rank(step3_indices, target_size=1, keep_hard=True)
+    assert len(final_indices) == 1
+    assert final_indices[0] == max(step3_indices, key=lambda idx: selector.el2n_scores[idx])
+
+
+def test_select_optimal_subset_with_dummy_extractors():
+    selector = _DummySelector()
+    image_paths = [f"image_{i}.jpg" for i in range(10)]
+
+    selected_indices, selected_paths, stats = selector.select_optimal_subset(
+        image_paths=image_paths,
+        target_size=3,
+        use_cache=False,
+    )
+
+    assert len(selected_indices) == 3
+    assert len(selected_paths) == 3
+    assert stats["original_count"] == len(image_paths)
+    assert stats["final_count"] == 3
+    assert set(selected_paths).issubset(set(image_paths))

--- a/AdvancedDatasetSelection/Tests/test_fourier_analyzer.py
+++ b/AdvancedDatasetSelection/Tests/test_fourier_analyzer.py
@@ -1,0 +1,41 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+
+# Ensure project root is on the path
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from AdvancedDatasetSelection.feature_extractors.fourier_analyzer import FourierAnalyzer
+
+
+def test_compute_frequency_features_returns_expected_shape_and_energy_split():
+    analyzer = FourierAnalyzer()
+    image = np.random.randint(0, 255, (32, 32, 3), dtype=np.uint8)
+
+    features = analyzer.compute_frequency_features(image)
+
+    assert features.shape == (5,)
+    assert np.isclose(np.sum(features[:3]), 1.0, atol=1e-5)
+    assert 0.0 <= features[3] <= 1.0
+    assert 0.0 <= features[4] <= 1.0
+
+
+def test_filter_redundant_removes_duplicate_frequency_signatures():
+    analyzer = FourierAnalyzer(similarity_threshold=0.98)
+
+    base_image = np.zeros((16, 16, 3), dtype=np.uint8)
+    vertical_stripes = base_image.copy()
+    vertical_stripes[:, ::2] = 255
+
+    features_a = analyzer.compute_frequency_features(base_image)
+    features_b = analyzer.compute_frequency_features(base_image)  # identical to features_a
+    features_c = analyzer.compute_frequency_features(vertical_stripes)
+
+    features = np.vstack([features_a, features_b, features_c])
+
+    selected_indices = analyzer.filter_redundant(features, threshold=0.97)
+
+    assert len(selected_indices) == 2
+    assert set(selected_indices) == {0, 2}

--- a/AdvancedDatasetSelection/__init__.py
+++ b/AdvancedDatasetSelection/__init__.py
@@ -8,8 +8,48 @@ This package provides tools for intelligent dataset selection using:
 - EL2N + k-Center: Sample selection methods from literature
 """
 
+from typing import TYPE_CHECKING
+
 __version__ = "1.0.0"
 __author__ = "PhD Project"
 
-from .feature_extractors import DINOExtractor, SAMExtractor, FourierAnalyzer
-from .selection_methods import EL2NScorer, KCenterGreedy, CombinedSelector
+if TYPE_CHECKING:  # pragma: no cover - import-time hints only
+    from .feature_extractors import DINOExtractor, SAMExtractor, FourierAnalyzer
+    from .selection_methods import EL2NScorer, KCenterGreedy, CombinedSelector
+
+__all__ = [
+    "CombinedSelector",
+    "DINOExtractor",
+    "EL2NScorer",
+    "FourierAnalyzer",
+    "KCenterGreedy",
+    "SAMExtractor",
+]
+
+
+def __getattr__(name):
+    if name == "DINOExtractor":
+        from .feature_extractors import DINOExtractor
+
+        return DINOExtractor
+    if name == "SAMExtractor":
+        from .feature_extractors import SAMExtractor
+
+        return SAMExtractor
+    if name == "FourierAnalyzer":
+        from .feature_extractors import FourierAnalyzer
+
+        return FourierAnalyzer
+    if name == "EL2NScorer":
+        from .selection_methods import EL2NScorer
+
+        return EL2NScorer
+    if name == "KCenterGreedy":
+        from .selection_methods import KCenterGreedy
+
+        return KCenterGreedy
+    if name == "CombinedSelector":
+        from .selection_methods import CombinedSelector
+
+        return CombinedSelector
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/AdvancedDatasetSelection/feature_extractors/__init__.py
+++ b/AdvancedDatasetSelection/feature_extractors/__init__.py
@@ -1,7 +1,26 @@
 """Feature extractors for dataset selection."""
 
-from .dino_extractor import DINOExtractor
-from .sam_extractor import SAMExtractor
-from .fourier_analyzer import FourierAnalyzer
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - type hints only
+    from .dino_extractor import DINOExtractor
+    from .fourier_analyzer import FourierAnalyzer
+    from .sam_extractor import SAMExtractor
 
 __all__ = ["DINOExtractor", "SAMExtractor", "FourierAnalyzer"]
+
+
+def __getattr__(name):
+    if name == "DINOExtractor":
+        from .dino_extractor import DINOExtractor
+
+        return DINOExtractor
+    if name == "SAMExtractor":
+        from .sam_extractor import SAMExtractor
+
+        return SAMExtractor
+    if name == "FourierAnalyzer":
+        from .fourier_analyzer import FourierAnalyzer
+
+        return FourierAnalyzer
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/AdvancedDatasetSelection/selection_methods/__init__.py
+++ b/AdvancedDatasetSelection/selection_methods/__init__.py
@@ -1,7 +1,26 @@
 """Selection methods for dataset curation."""
 
-from .el2n_scorer import EL2NScorer
-from .k_center_greedy import KCenterGreedy
-from .combined_selector import CombinedSelector
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - import-time hints only
+    from .combined_selector import CombinedSelector
+    from .el2n_scorer import EL2NScorer
+    from .k_center_greedy import KCenterGreedy
 
 __all__ = ["EL2NScorer", "KCenterGreedy", "CombinedSelector"]
+
+
+def __getattr__(name):
+    if name == "EL2NScorer":
+        from .el2n_scorer import EL2NScorer
+
+        return EL2NScorer
+    if name == "KCenterGreedy":
+        from .k_center_greedy import KCenterGreedy
+
+        return KCenterGreedy
+    if name == "CombinedSelector":
+        from .combined_selector import CombinedSelector
+
+        return CombinedSelector
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/AdvancedDatasetSelection/selection_methods/combined_selector.py
+++ b/AdvancedDatasetSelection/selection_methods/combined_selector.py
@@ -8,18 +8,20 @@ Implements 4-step selection strategy:
 4. EL2N ranking (difficulty)
 """
 
-import numpy as np
-from typing import List, Dict, Optional, Tuple
-from pathlib import Path
 import logging
-from tqdm import tqdm
 import pickle
+from pathlib import Path
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+
+import numpy as np
+from tqdm import tqdm
 
 from ..feature_extractors.fourier_analyzer import FourierAnalyzer
-from ..feature_extractors.dino_extractor import DINOExtractor
-from ..feature_extractors.sam_extractor import SAMExtractor
-from .el2n_scorer import EL2NScorer, compute_proxy_el2n_from_features
 from .k_center_greedy import KCenterGreedy
+
+if TYPE_CHECKING:  # pragma: no cover - avoids heavy imports at runtime
+    from ..feature_extractors.dino_extractor import DINOExtractor
+    from ..feature_extractors.sam_extractor import SAMExtractor
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -30,9 +32,9 @@ class CombinedSelector:
 
     def __init__(self,
                  fourier_analyzer: Optional[FourierAnalyzer] = None,
-                 dino_extractor: Optional[DINOExtractor] = None,
-                 sam_extractor: Optional[SAMExtractor] = None,
-                 el2n_scorer: Optional[EL2NScorer] = None,
+                 dino_extractor: Optional["DINOExtractor"] = None,
+                 sam_extractor: Optional["SAMExtractor"] = None,
+                 el2n_scorer=None,
                  k_center: Optional[KCenterGreedy] = None,
                  weights: Optional[Dict[str, float]] = None,
                  cache_dir: Optional[str] = None):
@@ -49,9 +51,23 @@ class CombinedSelector:
             cache_dir: Directory for caching features
         """
         self.fourier = fourier_analyzer or FourierAnalyzer()
-        self.dino = dino_extractor or DINOExtractor()
-        self.sam = sam_extractor or SAMExtractor()
-        self.el2n = el2n_scorer or EL2NScorer()
+
+        if dino_extractor is None:
+            from ..feature_extractors.dino_extractor import DINOExtractor
+
+            dino_extractor = DINOExtractor()
+        if sam_extractor is None:
+            from ..feature_extractors.sam_extractor import SAMExtractor
+
+            sam_extractor = SAMExtractor()
+
+        self.dino = dino_extractor
+        self.sam = sam_extractor
+        self.el2n = el2n_scorer
+        if self.el2n is None:
+            from .el2n_scorer import EL2NScorer
+
+            self.el2n = EL2NScorer()
         self.k_center = k_center or KCenterGreedy()
 
         self.weights = weights or {
@@ -167,6 +183,8 @@ class CombinedSelector:
 
         if len(labels) != len(valid_image_paths):
             labels = labels[:len(valid_image_paths)]
+
+        from .el2n_scorer import compute_proxy_el2n_from_features
 
         self.el2n_scores = compute_proxy_el2n_from_features(
             self.dino_features, np.array(labels)


### PR DESCRIPTION
## Summary
- add synthetic pytest coverage for the Fourier analyzer and combined selector using lightweight fixtures
- introduce lazy module loading to avoid importing heavy dependencies during test discovery
- ensure combined selector supports injected components for easier testing

## Testing
- pytest AdvancedDatasetSelection/Tests -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937f95f33c4832dacf94767a78fa14f)